### PR TITLE
Playing: Add a user model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Style/MixinUsage:
 Metrics/AbcSize:
   Exclude:
     - 'bin/*'
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space

--- a/.smells.reek
+++ b/.smells.reek
@@ -1,6 +1,7 @@
 ---
 exclude_paths:
   - node_modules
+  - db/migrate
 IrresponsibleModule:
   exclude:
   - ApplicationCable::Channel
@@ -11,3 +12,7 @@ IrresponsibleModule:
   - ApplicationMailer
   - ApplicationRecord
   - Jimmy::Application
+UtilityFunction:
+  exclude:
+  - Jimmy::Error
+  - Jimmy::ExampleError

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,11 @@ gem 'sidekiq'
 # Styling
 gem 'sass-rails', '~> 5.0'
 
+# Pry
+gem 'pry'
+gem 'pry-doc'
+gem 'pry-rails'
+
 # Javascript
 gem 'react-rails'
 gem 'uglifier', '>= 1.3.0'
@@ -61,9 +66,6 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'hookup'
   gem 'meta_request' # Supporting gem for RailsPanel chrome extension.
-  gem 'pry'
-  gem 'pry-doc'
-  gem 'pry-rails'
   gem 'stackprof' # Used by derailed gem for profiling
 
   # Testing

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'sidekiq'
 gem 'sass-rails', '~> 5.0'
 
 # Pry
+gem 'awesome_print'
 gem 'pry'
 gem 'pry-doc'
 gem 'pry-rails'
@@ -58,7 +59,6 @@ gem 'paranoia', '~> 2.2' # Soft Deletion
 
 group :development, :test do
   # Development
-  gem 'awesome_print'
   gem 'better_errors' # Better Rails error pages
   gem 'binding_of_caller' # Required by better errors.
   gem 'byebug', platforms: %i[mri mingw x64_mingw] # Debugger. Call 'byebug'.

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 release: bundle exec bin/rails db:migrate
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml

--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
   "environments": {
     "test": {
       "addons": [
-        "heroku-redis",
+        "heroku-redis:hobby-dev",
         "heroku-postgresql"
       ]
     }

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This controller handles all basic, publically-available actions.
+#  It is analogous to the welcome controller in most rails apps.
 class SiteController < ApplicationController
   def index; end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
   RESERVED_USERNAMES = %w[admin superuser administrator root jimmy].freeze
 
   # Validations
-  validates :name, presence: true, length: { maximum: 300 }
-  validates :username, presence: true, exclusion: { in: RESERVED_USERNAMES }
+  validates :name, presence: true, length: {maximum: 300}
+  validates :username, presence: true, exclusion: {in: RESERVED_USERNAMES}
   validates :primary_email, presence: true, format: /@/
 
   # Override ActiveRecord getter because hstore returns keys as strings.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,10 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 300 }
   validates :username, presence: true, exclusion: { in: RESERVED_USERNAMES }
   validates :primary_email, presence: true, format: /@/
+
+  # Override ActiveRecord getter because hstore returns keys as strings.
+  def metadata
+    return unless self[:metadata]
+    self[:metadata].deep_symbolize_keys
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# The User model represents individual users in the system.
+class User < ApplicationRecord
+  RESERVED_USERNAMES = %w[admin superuser administrator root jimmy].freeze
+
+  # Validations
+  validates :name, presence: true, length: { maximum: 300 }
+  validates :username, presence: true, exclusion: { in: RESERVED_USERNAMES }
+  validates :primary_email, presence: true, format: /@/
+end

--- a/app/workers/example_worker.rb
+++ b/app/workers/example_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This is an example worker. It does nothing useful, but
+#   along with its associated test and rake task it shows
+#   the pattern for how workers should be written in Jimmy
+
+class ExampleWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :scheduled_tasks, retry: false
+
+  def perform(name, email)
+    Rails.logger.info 'Starting Example Worker'
+
+    # Do something
+    User.create(name: name,
+                username: name.downcase.tr(' ', ''),
+                primary_email: email)
+
+    sleep 20 unless Rails.env.test? # Simulate a slow task
+
+    Rails.logger.info 'Example Worker Finished'
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,8 @@ module Jimmy
     config.generators.system_tests = nil
 
     # Use UUIDs as primary keys in activerecord.
-    config.generators do |g|
-      g.orm :active_record, primary_key_type: :uuid
+    config.generators do |generator|
+      generator.orm :active_record, primary_key_type: :uuid
     end
 
     # Require everything in lib/jimmy

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -6,6 +6,6 @@ Rails.application.configure do
   config.lograge.keep_original_rails_log = (Rails.env == 'development' && !ENV['CONCISE_LOG'])
 
   config.lograge.custom_options = lambda do |event|
-    { time: event.time }
+    {time: event.time}
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -61,7 +61,7 @@ lowlevel_error_handler do |exception, env|
   Raven.capture_exception(
     exception,
     message: exception.message,
-    extra: { puma: env },
+    extra: {puma: env},
     transaction: 'Puma'
   )
   # Send a Rack response to the client

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+---
+:concurrency: 10
+:queues:
+  - scheduled_tasks

--- a/db/migrate/20180301234220_create_users.rb
+++ b/db/migrate/20180301234220_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'pgcrypto'
+    create_table :users, id: :uuid do |t|
+      t.string :username,                         null: false
+      t.string :primary_email,                    null: false
+      t.string :name,                             null:false
+
+      t.timestamps
+    end
+    add_index :users, :username
+  end
+end

--- a/db/migrate/20180302193651_enable_hstore_extensionv.rb
+++ b/db/migrate/20180302193651_enable_hstore_extensionv.rb
@@ -1,0 +1,5 @@
+class EnableHstoreExtensionv < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'hstore'
+  end
+end

--- a/db/migrate/20180302194554_add_meta_data_to_user.rb
+++ b/db/migrate/20180302194554_add_meta_data_to_user.rb
@@ -1,0 +1,5 @@
+class AddMetaDataToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :metadata, :hstore
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301234220) do
+ActiveRecord::Schema.define(version: 20180302193651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pgcrypto"
+  enable_extension "hstore"
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "username", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180302193651) do
+ActiveRecord::Schema.define(version: 20180302194554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20180302193651) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.hstore "metadata"
     t.index ["username"], name: "index_users_on_username"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20180301234220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pgcrypto"
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "username", null: false
+    t.string "primary_email", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["username"], name: "index_users_on_username"
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,6 @@
 
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+# Create basic user
+User.create! username: 'dannysmith', primary_email: 'hi@danny.is', name: 'Danny Smith', metadata: {note: 'This is a seed account'}

--- a/lib/jimmy/error.rb
+++ b/lib/jimmy/error.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+# frozen_string_literal: true
+
 module Jimmy
   # Abstract Error class
   #
   # * All errors should inherit from Jimmy::Error
   # * Takes additional metadata and severity.
-
   class Error < StandardError
     attr_reader :metadata, :severity
 

--- a/lib/jimmy/error_handler.rb
+++ b/lib/jimmy/error_handler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Custom error handler to be used in all rescue blocks when dealing with errors and exceptions.
 module Jimmy
+  # Custom error handler to be used in all rescue blocks when dealing with errors and exceptions.
   class ErrorHandler
     def self.handle(error, severity = :error, metadata = {})
       # Send errors to Sentry

--- a/lib/jimmy/example_error.rb
+++ b/lib/jimmy/example_error.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-# Custom erros like this can be used alongside the ErrorHandler
-#
-#   Where the error is raised:
-#
-#     raise Jimmy::ExampleError.new('Whoops, an error occured',
-#                                 :fatal,
-#                                 {details: 'Some data here'})
-#
-#   Where the error is handled:
-#
-#     rescue Jimmy::ExampleError => e
-#       Jimmy::ErrorHandler.handle(e, e.severity, e.metadata)
-#       flash[:error] = e.user_message
-#       redirect_to :somewhere
-#     end
+# frozen_string_literal: true
+
 module Jimmy
+  # Custom erros like this can be used alongside the ErrorHandler
+  #
+  #   Where the error is raised:
+  #
+  #     raise Jimmy::ExampleError.new('Whoops, an error occured',
+  #                                 :fatal,
+  #                                 {details: 'Some data here'})
+  #
+  #   Where the error is handled:
+  #
+  #     rescue Jimmy::ExampleError => e
+  #       Jimmy::ErrorHandler.handle(e, e.severity, e.metadata)
+  #       flash[:error] = e.user_message
+  #       redirect_to :somewhere
+  #     end
   class ExampleError < Jimmy::Error
     def user_message
       I18n.t('errors.example')

--- a/lib/tasks/examples.rake
+++ b/lib/tasks/examples.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :examples do
+  desc 'Example Task to show the form workers should take'
+  task run_example_worker: :environment do
+    ExampleWorker.perform_async('Mr Blobby')
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    username 'joebloggs'
+    primary_email 'jo2_bloggs@example.com'
+    name 'Joe H. Bloggs'
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it { should validate_presence_of(:username) }
+  it { should validate_presence_of(:primary_email) }
+  it { should validate_presence_of(:name) }
+
+  it { should validate_exclusion_of(:username).in_array(%w[admin superuser administrator root jimmy]) }
+  it { should validate_length_of(:name).is_at_most(300) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe User, type: :model do
     it 'Returns metadata as a key symbolized hash' do
       user.metadata = {'note' => 'some note', 'some_flag' => true}
       user.save!
-      expect(user.metadata.has_key? :note).to be true
-      expect(user.metadata.has_key? :some_flag).to be true
+      expect(user.metadata.key?(:note)).to be true
+      expect(user.metadata.key?(:some_flag)).to be true
 
       # hstore always returns values as trings
       expect(user.metadata[:some_flag]).to eq 'true'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,10 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it { should validate_presence_of(:username) }
-  it { should validate_presence_of(:primary_email) }
-  it { should validate_presence_of(:name) }
+  context 'Validations' do
+    it { should validate_presence_of(:username) }
+    it { should validate_presence_of(:primary_email) }
+    it { should validate_presence_of(:name) }
 
-  it { should validate_exclusion_of(:username).in_array(%w[admin superuser administrator root jimmy]) }
-  it { should validate_length_of(:name).is_at_most(300) }
+    it { should validate_exclusion_of(:username).in_array(%w[admin superuser administrator root jimmy]) }
+    it { should validate_length_of(:name).is_at_most(300) }
+  end
+
+  context 'Instance methods' do
+    let(:user) { create(:user) }
+
+    it 'Returns metadata as a key symbolized hash' do
+      user.metadata = {'note' => 'some note', 'some_flag' => true}
+      user.save!
+      expect(user.metadata.has_key? :note).to be true
+      expect(user.metadata.has_key? :some_flag).to be true
+
+      # hstore always returns values as trings
+      expect(user.metadata[:some_flag]).to eq 'true'
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,9 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  # Include FactoryBot helpers
+  config.include FactoryBot::Syntax::Methods
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/workers/example_worker_worker_spec.rb
+++ b/spec/workers/example_worker_worker_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExampleWorker, type: :worker do
+  describe '#perform' do
+    let(:worker) { subject }
+
+    # This is the purpose of the example worker. It creates a new user.
+    it 'creates a new user' do
+      # Run the worker by calling `perform` on it.
+      worker.perform('Mister ExampleWorker Test', 'jane@example.com')
+
+      # Verify that the worker did what it was supposed to
+      user = User.where(name: 'Mister ExampleWorker Test').last
+      expect(user).not_to be_nil
+      expect(user.primary_email).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a simple user model, with validation at the database and model levels, along with a unit test for the user model. It also has an associated factory.

The mgration also installs the required postgres extension to allow  UUID PKs and adds an index on username to the user table for faster querying by username.

There is also some cleaning up to keep reek and rubocop happy.