### PR TITLE
Better Logging with UUIDs

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -6,6 +6,9 @@ Rails.application.configure do
   config.lograge.keep_original_rails_log = (Rails.env.development? && !ENV['CONCISE_LOG'])
 
   config.lograge.custom_options = lambda do |event|
-    {time: event.time}
+    {
+      time: event.time,
+      uid: event.payload[:uid],
+    }
   end
 end


### PR DESCRIPTION
Initially, this just adds a UUID to all request loglines for ease of searching logs/reporting bugs etc. In the future, we might want to consider moving this UUID onto the **actual rack request** object and exposing it via `Current` so that it can be passed on to other microservices and the like.