### PR TITLE
Add Admin Flag to User

### DIFF
--- a/app/models/route_constraints/admin.rb
+++ b/app/models/route_constraints/admin.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This constraint can used in the routes file.
+#   See https://guides.rubyonrails.org/routing.html#advanced-constraints
+#
+module RouteConstraint
+  class Admin
+    def matches?(request)
+      user = User.find_by(id: request.session[:user_id])
+      user&.admin?
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # The User model represents individual users in the system.
 class User < ApplicationRecord
   RESERVED_USERNAMES = %w[admin superuser administrator root jimmy].freeze
+  ADMINISTRATORS = %w[dannysmith].freeze
 
   # Fields and Relations
   has_secure_password
@@ -17,6 +18,12 @@ class User < ApplicationRecord
   def self.lookup_by_email_or_username(email_or_username)
     find_by(username: email_or_username) ||
       find_by(primary_email: email_or_username)
+  end
+
+  # Instance Mathods
+
+  def admin?
+    ADMINISTRATORS.include? username
   end
 
   # Override ActiveRecord getter because hstore returns keys as strings.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+require_relative '../app/models/route_constraints/admin.rb'
 
 # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
@@ -25,12 +26,11 @@ Rails.application.routes.draw do
   root to: 'site#index'
 
   #############################################################
-  ###                      PUBLIC SITE                      ###
+  ###                       ADMIN SITE                      ###
   #############################################################
 
-  # TODO: Scope these to admin users once devise is installed.
-  # authenticate :user, -> (user) { user.admin? } do
-  mount PgHero::Engine, at: 'admin/pghero'
-  mount Sidekiq::Web, at: 'admin/sidekiq'
-  # end
+  namespace :admin, constraints: RouteConstraint::Admin.new do
+    mount PgHero::Engine, at: 'pghero'
+    mount Sidekiq::Web, at: 'sidekiq'
+  end
 end


### PR DESCRIPTION
This adds an `admin?` flag tot he user. I've hard-coded this as a list
of udernames, initially, for the sake of simplicity. Eventually, this
may need to be migrated to a column of the user table.

This, along with a new `route_constraints` pattern is used to lock the
Sidekiq and PGHero panesl to admins only.

See https://guides.rubyonrails.org/routing.html#advanced-constraints for
more on constraints.

The admin constrain is directly required in the routes.rb in order to
discourage overuse of constrains like this. In general, they should only
be used when mounting stuff from engines.

Related to #133