### PR TITLE
Add Undercover gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'undercover'
 
   # Dynamic Analysis
   gem 'bullet' # N+1 Queries
@@ -118,7 +119,8 @@ group :development do
 end
 
 group :test do
-  gem 'simplecov', require: false # Code coverage
+  gem 'simplecov' # Code coverage
+  gem 'simplecov-lcov'
   gem 'test-prof' # A Suite of testing tools
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    imagen (0.1.4)
+      parser (>= 2.5, != 2.5.1.1)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -359,6 +361,7 @@ GEM
       ruby_parser (~> 3.8)
       tty-which (~> 0.3.0)
       virtus (~> 1.0)
+    rugged (0.27.4)
     sandi_meter (1.2.0)
       json
       launchy
@@ -392,6 +395,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    simplecov-lcov (0.7.0)
     skylight (2.0.2)
       skylight-core (= 2.0.2)
     skylight-core (2.0.2)
@@ -431,6 +435,10 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.16)
       execjs (>= 0.3.0, < 3)
+    undercover (0.1.4)
+      imagen (~> 0.1.2)
+      rainbow (~> 3.0.0)
+      rugged (~> 0.27.0)
     unicode-display_width (1.4.0)
     uniform_notifier (1.11.0)
     virtus (1.0.5)
@@ -512,6 +520,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   sidekiq
   simplecov
+  simplecov-lcov
   skylight
   spring
   spring-commands-rspec
@@ -523,6 +532,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  undercover
   web-console (>= 3.3.0)
   webpacker
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,15 @@
 
 # Send test metrics
 require 'simplecov'
-SimpleCov.start 'rails'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.start do
+  add_filter(%r{^\/spec\/}) # For RSpec
+end
+
+require 'undercover'
 
 # Load Test Environment
 require 'spec_helper'


### PR DESCRIPTION
This adds the undercover gem <https://github.com/grodowski/undercover> for highlighting untested lines of code since the last commit.

See the project README for details on how to use it.


- [ ] Use both new SimpleCov formatter **and** original "rails" formatter.
- [ ] Add `bundle exec undercover --compare master` to CI build.
- [ ] Add undercover to `bin/analyze` or similar.